### PR TITLE
Align magic number and slippage with Python defaults

### DIFF
--- a/ConvertedEA.mq4
+++ b/ConvertedEA.mq4
@@ -1,8 +1,8 @@
 #property strict
 
-extern int    InpMagic=12112;
+extern int    InpMagic=0;
 extern double InpBaseLot=0.02;
-extern int    InpSlippagePoints=10;
+extern int    InpSlippagePoints=100;
 extern double InpMaxSpreadPips=2.0;
 extern bool   InpVerboseLog=true;
 extern bool   InpNettingEmulation=false;


### PR DESCRIPTION
## Summary
- Sync default magic number and slippage with Python script constants

## Testing
- `python -m py_compile grid_chisiki.py`


------
https://chatgpt.com/codex/tasks/task_e_68a1a612c4ec832790c8be9bb7014d8c