### PR TITLE
fix: refine grid EA parameters

### DIFF
--- a/StopGridTrader.mq4
+++ b/StopGridTrader.mq4
@@ -1,5 +1,4 @@
 #property strict
-#property indicator_chart_window
 
 input string  SymbolName      = "XAUUSD";   // Symbol name
 input int     PriceDigits     = 2;           // Price digits
@@ -128,6 +127,13 @@ void CheckPartial()
 //---- expert initialization
 int OnInit()
 {
+   int lot100 = (int)MathRound(BaseLot * 100);
+   if(PriceDigits < 0 || lot100 < 2 || lot100 % 2 != 0 ||
+      OrdersPerSide < 1 || GridMultiplier <= 0 || LoopCount < 0)
+   {
+      Print("Invalid input parameters");
+      return(INIT_PARAMETERS_INCORRECT);
+   }
    BuildGrid();
    return(INIT_SUCCEEDED);
 }


### PR DESCRIPTION
## Summary
- drop indicator-only property from StopGridTrader.mq4
- validate user-supplied inputs just like original Python version

## Testing
- `python -m py_compile grid_chisiki.py`


------
https://chatgpt.com/codex/tasks/task_e_68a1c5a0ee788327bdea5d95b2766012