### PR TITLE
Avoid skipping positions when closing orders

### DIFF
--- a/StopGridTrader.mq4
+++ b/StopGridTrader.mq4
@@ -104,7 +104,8 @@ void CheckPartial()
 {
    double ask = MarketInfo(SymbolName, MODE_ASK);
    double bid = MarketInfo(SymbolName, MODE_BID);
-   for(int i=0;i<OrdersTotal();i++)
+   // iterate backwards so closing a position doesn't skip the next one
+   for(int i=OrdersTotal()-1; i>=0; i--)
    {
       if(!OrderSelect(i, SELECT_BY_POS, MODE_TRADES)) continue;
       if(OrderSymbol()!=SymbolName || OrderMagicNumber()!=MAGIC_NUMBER) continue;


### PR DESCRIPTION
## Summary
- iterate `CheckPartial` loop in reverse to handle order removal safely

## Testing
- `python -m py_compile grid_chisiki.py`
- `wine MetaEditor.exe /compile:StopGridTrader.mq4` *(fails: Application could not be started)*

------
https://chatgpt.com/codex/tasks/task_e_68a1c774164c8327aace21c41f657a8a